### PR TITLE
CU-24x518n Get subteams data from teams Redux call instead of mock data

### DIFF
--- a/src/frontend/components/DropdownMenu/DropdownMenu.js
+++ b/src/frontend/components/DropdownMenu/DropdownMenu.js
@@ -92,7 +92,7 @@ const DropdownMenu = ({
                 opacity: 0.5,
               }),
             }}
-            disableTouchRipple={emailSent ? true : false}
+            disableTouchRipple={emailSent}
           >
             <ListItemText primary={options[current]} />
             <Chevron src={chevron} alt="chevron" />

--- a/src/frontend/hooks/teams.js
+++ b/src/frontend/hooks/teams.js
@@ -4,6 +4,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import api from '../api';
 import * as teamsActions from '../state/teams/actions';
 import * as teamsSelectors from '../state/teams/selectors';
+import { renameObjectKeys } from '../pages/recruitment/utils';
 
 const useTeams = () => {
   const dispatch = useDispatch();
@@ -14,6 +15,7 @@ const useTeams = () => {
     try {
       const teams = await api.teams.getTeams();
       const teamDesc = await api.teams.getTeamDesc();
+      renameObjectKeys(teams.data, 'teamName', 'name');
 
       return {
         teams: teams.data,

--- a/src/frontend/pages/recruitment/ApplicationPage/ApplicationPage.js
+++ b/src/frontend/pages/recruitment/ApplicationPage/ApplicationPage.js
@@ -14,7 +14,6 @@ import {
   setCheckboxesShown,
   oneTrue,
   getItemByName,
-  renameObjectKeys,
 } from '../utils';
 
 import useApplications from '../../../hooks/applications';
@@ -27,7 +26,6 @@ const ApplicationPage = () => {
   const { applications } = useApplications('FALL-2022'); // TODO: in production, replace with Date.now().
   const { postings } = usePostings();
   const { teams } = useTeams();
-  renameObjectKeys(teams, 'teamName', 'name');
 
   // Grab applications data from backend
   const tableRows = applications.map((application) => {
@@ -70,7 +68,7 @@ const ApplicationPage = () => {
     })
     .filter((position) => position.name !== undefined);
 
-  const subteamsUnformatted = teams.map((subteam) => subteam.teamName);
+  const subteamsUnformatted = teams.map((subteam) => subteam.name);
   const termTypesUnformatted = TERM_TYPE_OPTIONS.map(
     (termType) => termType.name,
   );

--- a/src/frontend/pages/recruitment/DecisionPage/DecisionPage.js
+++ b/src/frontend/pages/recruitment/DecisionPage/DecisionPage.js
@@ -1,21 +1,23 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 
 import EmailModal from '../../../components/EmailModal';
 import PortalTemplate from '../components/PortalTemplate';
 import { tabs, tableColumns, positionFields } from './Constants';
 import { makeTruthTable, createData, getItemById } from '../../../utils';
-import { SUBTEAM_OPTIONS, MIN_SUBTEAMS_SHOWN } from '../components/Constants';
+import { MIN_SUBTEAMS_SHOWN } from '../components/Constants';
 import {
   setCheckboxValues,
   setCheckboxesShown,
   oneTrue,
   getItemByName,
+  renameObjectKeys,
 } from '../utils';
 import Button from '../../../components/Button';
 
 import usePostings from '../../../hooks/postings';
 import useApplications from '../../../hooks/applications';
 import useEmail from '../../../hooks/email';
+import useTeams from '../../../hooks/teams';
 
 const DecisionPage = () => {
   const [modalOpen, setModalOpen] = useState(false);
@@ -24,6 +26,8 @@ const DecisionPage = () => {
   const { applications } = useApplications('FALL-2022');
   const { postings } = usePostings();
   const { updateEmailSent } = useEmail();
+  const { teams } = useTeams();
+  renameObjectKeys(teams, 'teamName', 'name');
 
   const handleButtonClick = (data) => {
     setEmailData(data);
@@ -77,11 +81,13 @@ const DecisionPage = () => {
 
   const [positionsChecked, setPositionsChecked] = useState({});
 
-  const subteamsUnformatted = SUBTEAM_OPTIONS.map((subteam) => subteam.name);
+  const subteamsUnformatted = teams.map((subteam) => subteam.teamName);
 
-  const [subteamsChecked, setSubteamsChecked] = useState(
-    makeTruthTable(subteamsUnformatted, false),
-  );
+  const [subteamsChecked, setSubteamsChecked] = useState({});
+
+  useEffect(() => {
+    setSubteamsChecked(makeTruthTable(subteamsUnformatted, false));
+  }, [teams]);
 
   const filterRows = (status) =>
     tableRows.filter(
@@ -95,7 +101,7 @@ const DecisionPage = () => {
     (position) => subteamsChecked[position.team],
   );
 
-  const MAX_SUBTEAMS_SHOWN = subteamsChecked.length;
+  const MAX_SUBTEAMS_SHOWN = teams.length;
 
   const [subteamsShown, setSubteamsShown] = useState(MIN_SUBTEAMS_SHOWN);
 
@@ -107,10 +113,9 @@ const DecisionPage = () => {
       checked: subteamsChecked,
       maxShown: MAX_SUBTEAMS_SHOWN,
       minShown: MIN_SUBTEAMS_SHOWN,
-      options: SUBTEAM_OPTIONS,
+      options: teams,
       setCategoryChecked: (clickedOption) => {
         setCheckboxValues(clickedOption, subteamsChecked, setSubteamsChecked);
-
         setPositionsChecked((prevState) => ({
           ...prevState,
           ...makeTruthTable(

--- a/src/frontend/pages/recruitment/DecisionPage/DecisionPage.js
+++ b/src/frontend/pages/recruitment/DecisionPage/DecisionPage.js
@@ -10,7 +10,6 @@ import {
   setCheckboxesShown,
   oneTrue,
   getItemByName,
-  renameObjectKeys,
 } from '../utils';
 import Button from '../../../components/Button';
 
@@ -27,7 +26,6 @@ const DecisionPage = () => {
   const { postings } = usePostings();
   const { updateEmailSent } = useEmail();
   const { teams } = useTeams();
-  renameObjectKeys(teams, 'teamName', 'name');
 
   const handleButtonClick = (data) => {
     setEmailData(data);
@@ -81,7 +79,7 @@ const DecisionPage = () => {
 
   const [positionsChecked, setPositionsChecked] = useState({});
 
-  const subteamsUnformatted = teams.map((subteam) => subteam.teamName);
+  const subteamsUnformatted = teams.map((subteam) => subteam.name);
 
   const [subteamsChecked, setSubteamsChecked] = useState({});
 

--- a/src/frontend/pages/recruitment/InterviewPage/InterviewPage.js
+++ b/src/frontend/pages/recruitment/InterviewPage/InterviewPage.js
@@ -1,10 +1,9 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useHistory } from 'react-router-dom';
 import PortalTemplate from '../components/PortalTemplate';
 import { tabs, tableColumns, positionFields } from './Constants';
 import { makeTruthTable, createData, getItemById } from '../../../utils';
 import {
-  SUBTEAM_OPTIONS,
   TERM_TYPE_OPTIONS,
   YEAR_OPTIONS,
   MIN_YEARS_SHOWN,
@@ -15,16 +14,20 @@ import {
   setCheckboxesShown,
   oneTrue,
   getItemByName,
+  renameObjectKeys,
 } from '../utils';
 
 import usePostings from '../../../hooks/postings';
 import useApplications from '../../../hooks/applications';
+import useTeams from '../../../hooks/teams';
 
 const InterviewPage = () => {
   const history = useHistory();
 
   const { applications } = useApplications('FALL-2022');
   const { postings } = usePostings();
+  const { teams } = useTeams();
+  renameObjectKeys(teams, 'teamName', 'name');
 
   // Grab applications data from backend
   const tableRows = applications.map((application) => {
@@ -67,15 +70,13 @@ const InterviewPage = () => {
     })
     .filter((position) => position.name !== undefined);
 
-  const subteamsUnformatted = SUBTEAM_OPTIONS.map((subteam) => subteam.name);
+  const subteamsUnformatted = teams.map((subteam) => subteam.teamName);
   const termTypesUnformatted = TERM_TYPE_OPTIONS.map(
     (termType) => termType.name,
   );
   const yearsUnformatted = YEAR_OPTIONS.map((year) => year.name);
 
-  const [subteamsChecked, setSubteamsChecked] = useState(
-    makeTruthTable(subteamsUnformatted, false),
-  );
+  const [subteamsChecked, setSubteamsChecked] = useState({});
   const [positionsChecked, setPositionsChecked] = useState({});
   const [termTypesChecked, setTermTypesChecked] = useState(
     makeTruthTable(termTypesUnformatted, true),
@@ -83,6 +84,10 @@ const InterviewPage = () => {
   const [yearsChecked, setYearsChecked] = useState(
     makeTruthTable(yearsUnformatted, true),
   );
+
+  useEffect(() => {
+    setSubteamsChecked(makeTruthTable(subteamsUnformatted, false));
+  }, [teams]);
 
   const filterRows = (status) =>
     tableRows.filter(
@@ -98,8 +103,8 @@ const InterviewPage = () => {
     (position) => subteamsChecked[position.team],
   );
 
-  const MAX_SUBTEAMS_SHOWN = subteamsChecked.length;
-  const MAX_YEARS_SHOWN = yearsChecked.length;
+  const MAX_SUBTEAMS_SHOWN = teams.length;
+  const MAX_YEARS_SHOWN = YEAR_OPTIONS.length;
 
   const [subteamsShown, setSubteamsShown] = useState(MIN_SUBTEAMS_SHOWN);
   const [yearsShown, setYearsShown] = useState(MIN_YEARS_SHOWN);
@@ -107,15 +112,14 @@ const InterviewPage = () => {
   const filterCategories = [
     {
       name: 'subteams',
-      formattedName: 'Subteams',
+      formattedName: 'Subteam',
       currentShown: subteamsShown,
       checked: subteamsChecked,
       maxShown: MAX_SUBTEAMS_SHOWN,
       minShown: MIN_SUBTEAMS_SHOWN,
-      options: SUBTEAM_OPTIONS,
+      options: teams,
       setCategoryChecked: (clickedOption) => {
         setCheckboxValues(clickedOption, subteamsChecked, setSubteamsChecked);
-
         setPositionsChecked((prevState) => ({
           ...prevState,
           ...makeTruthTable(

--- a/src/frontend/pages/recruitment/InterviewPage/InterviewPage.js
+++ b/src/frontend/pages/recruitment/InterviewPage/InterviewPage.js
@@ -14,7 +14,6 @@ import {
   setCheckboxesShown,
   oneTrue,
   getItemByName,
-  renameObjectKeys,
 } from '../utils';
 
 import usePostings from '../../../hooks/postings';
@@ -27,7 +26,6 @@ const InterviewPage = () => {
   const { applications } = useApplications('FALL-2022');
   const { postings } = usePostings();
   const { teams } = useTeams();
-  renameObjectKeys(teams, 'teamName', 'name');
 
   // Grab applications data from backend
   const tableRows = applications.map((application) => {
@@ -70,7 +68,7 @@ const InterviewPage = () => {
     })
     .filter((position) => position.name !== undefined);
 
-  const subteamsUnformatted = teams.map((subteam) => subteam.teamName);
+  const subteamsUnformatted = teams.map((subteam) => subteam.name);
   const termTypesUnformatted = TERM_TYPE_OPTIONS.map(
     (termType) => termType.name,
   );

--- a/src/frontend/pages/recruitment/components/Constants.js
+++ b/src/frontend/pages/recruitment/components/Constants.js
@@ -6,20 +6,6 @@ export const colNames = [
   'POSITION',
 ];
 
-export const SUBTEAM_OPTIONS = [
-  { name: 'WebTeam', formattedName: 'Web' },
-  { name: 'Electrical', formattedName: 'Electrical' },
-  { name: 'Mechanical', formattedName: 'Mechanical' },
-  { name: 'LIM', formattedName: 'LIM' },
-  { name: 'Business', formattedName: 'Business' },
-  { name: 'Infrastructure', formattedName: 'Infrastructure' },
-  { name: 'Propulsion', formattedName: 'Propulsion' },
-  { name: 'BMS', formattedName: 'BMS' },
-  { name: 'Embedded', formattedName: 'Embedded' },
-  { name: 'MotorControl', formattedName: 'Motor Control' },
-  { name: 'Communications', formattedName: 'Communications' },
-];
-
 export const TERM_TYPE_OPTIONS = [
   { name: 'study', formattedName: 'Study' },
   { name: 'coop', formattedName: 'Co-op' },

--- a/src/frontend/pages/recruitment/components/PortalFilterTemplate.js
+++ b/src/frontend/pages/recruitment/components/PortalFilterTemplate.js
@@ -76,7 +76,8 @@ const PortalFilterTemplate = ({ filterCategories }) => (
         <CheckboxGroup sx={{ m: 3 }} component="fieldset" variant="standard">
           <CheckboxCategoryName>{category.formattedName}</CheckboxCategoryName>
           <FormGroup>
-            {category.currentShown !== 0 ? (
+            {category.currentShown !== 0 &&
+            Object.keys(category.checked).length !== 0 ? (
               category.options
                 .slice(0, category.currentShown)
                 .map((checkbox) => (
@@ -96,7 +97,11 @@ const PortalFilterTemplate = ({ filterCategories }) => (
                       />
                     }
                     label={
-                      <CheckboxName>{checkbox.formattedName}</CheckboxName>
+                      <CheckboxName>
+                        {'formattedName' in checkbox
+                          ? checkbox.formattedName
+                          : checkbox.name}
+                      </CheckboxName>
                     }
                     key={checkbox.name}
                   />
@@ -107,7 +112,7 @@ const PortalFilterTemplate = ({ filterCategories }) => (
               </NoEntriesDefaultText>
             )}
           </FormGroup>
-          {category.setCategoryShown && (
+          {category.setCategoryShown && category.minShown < category.maxShown && (
             <ShowMoreAndLessButton
               variant="text"
               onClick={category.setCategoryShown}

--- a/src/frontend/pages/recruitment/utils.js
+++ b/src/frontend/pages/recruitment/utils.js
@@ -39,6 +39,7 @@ export const getItemByName = (arr, name) => {
 export const renameObjectKeys = (arr, oldKey, newKey) => {
   const newArr = arr.map((obj) => {
     obj[newKey] = obj[oldKey];
+    delete obj[oldKey];
     return obj;
   });
   return newArr;

--- a/src/frontend/pages/recruitment/utils.js
+++ b/src/frontend/pages/recruitment/utils.js
@@ -35,3 +35,11 @@ export const getItemByName = (arr, name) => {
   const obj = arr.filter((item) => item.name === name);
   return obj[0];
 };
+/* eslint-disable */
+export const renameObjectKeys = (arr, oldKey, newKey) => {
+  const newArr = arr.map((obj) => {
+    obj[newKey] = obj[oldKey];
+    return obj;
+  });
+  return newArr;
+};

--- a/src/frontend/tests/recruitment/application-page/Constants.js
+++ b/src/frontend/tests/recruitment/application-page/Constants.js
@@ -1,0 +1,13 @@
+export const SUBTEAM_OPTIONS = [
+    { name: 'WebTeam', formattedName: 'Web' },
+    { name: 'Electrical', formattedName: 'Electrical' },
+    { name: 'Mechanical', formattedName: 'Mechanical' },
+    { name: 'LIM', formattedName: 'LIM' },
+    { name: 'Business', formattedName: 'Business' },
+    { name: 'Infrastructure', formattedName: 'Infrastructure' },
+    { name: 'Propulsion', formattedName: 'Propulsion' },
+    { name: 'BMS', formattedName: 'BMS' },
+    { name: 'Embedded', formattedName: 'Embedded' },
+    { name: 'MotorControl', formattedName: 'Motor Control' },
+    { name: 'Communications', formattedName: 'Communications' },
+  ];


### PR DESCRIPTION
### [CLICKUP TICKET LINK](https://app.clickup.com/t/24x518n)

- Use teams Redux call to get subteams instead of mock data
- Moved subteams mock data to `executive-dashboard\src\frontend\tests\recruitment\application-page\Constants.js`
- Similar changes across Application, Interview, and Decision Portals
- Edited PortalFilterTemplate to accommodate changes

### Type of change

- New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

- [x] Ensured portals frontend still worked as intended