### PR TITLE
To get accessToken from request headers instead of sending it in the …

### DIFF
--- a/src/backend/api/email/update-email-sent.js
+++ b/src/backend/api/email/update-email-sent.js
@@ -4,9 +4,23 @@ import { sendEmail } from './helper';
 export default async (req, res) => {
   const appID = req.body.id;
 
-  // send the actual email, then check if email sent correctly
-  if (req.body.accessToken) {
-    await sendEmail(req.body, req.body.accessToken); // TODO: check if accessToken sent securely.
+  const cookieHeader = req.headers?.cookie;
+  if (cookieHeader) {
+    const list = {};
+    cookieHeader.split(';').forEach(cookie => {
+      let [name, ...rest] = cookie.split('=');
+      name = name?.trim();
+      if (!name) return;
+      const value = rest.join('=').trim();
+      if (!value) return;
+      list[name] = decodeURIComponent(value);
+    });
+    console.log('cookieHeader::', list)
+
+    // send the actual email, then check if email sent correctly
+    if (list.accessToken) {
+      await sendEmail(req.body, list.accessToken); // TODO: check if accessToken sent securely.
+    }
   }
 
   try {

--- a/src/frontend/hooks/email.js
+++ b/src/frontend/hooks/email.js
@@ -2,7 +2,6 @@ import { useCallback } from 'react';
 import { useDispatch } from 'react-redux';
 import api from 'frontend/api';
 import * as applicationActions from 'frontend/state/applications/actions';
-import CookiesHelper from './cookies.js';
 
 const useEmail = () => {
   const dispatch = useDispatch();
@@ -10,12 +9,7 @@ const useEmail = () => {
   const updateEmailStatus = useCallback(
     async (emailData) => {
       try {
-        const { getCookie, CookieTags } = CookiesHelper;
-        const accessToken = getCookie(CookieTags.accessToken);
-        const res = await api.email.updateApplicationEmailSent({
-          ...emailData,
-          accessToken,
-        });
+        const res = await api.email.updateApplicationEmailSent(emailData);
 
         if (res.status !== 200) {
           throw new Error(


### PR DESCRIPTION
…body.

### CLICKUP TICKET LINK: https://app.clickup.com/t/860pjn7w1

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

> Instead of sending the access token through the API body, I changed it so that it reads the access token in the backend through the cookie headers
> Change 2

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Checked "/example" endpoint on postman
- [ ] Change passes all integration tests

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation/READ-ME/UMLS (if applicable)
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
