### PR TITLE
Fix Long Applicant Name Issue

### DIFF
--- a/src/frontend/components/ProfileTemplate/Header/Header.js
+++ b/src/frontend/components/ProfileTemplate/Header/Header.js
@@ -26,7 +26,9 @@ const BackArrow = styled.button`
 
 const HeaderGrid = styled(Grid)`
   width: 100%;
-  position: absolute;
+  position: relative;
+  margin-bottom: -150px;
+  overflow: auto;
   z-index: 1;
   padding: 64px 82px 10px 82px;
   background-color: #a3f4e4;

--- a/src/frontend/components/ProfileTemplate/Header/Header.js
+++ b/src/frontend/components/ProfileTemplate/Header/Header.js
@@ -15,7 +15,7 @@ const BackArrow = styled.button`
   font: inherit;
   cursor: pointer;
   outline: inherit;
-  position: fixed;
+  position: absolute;
   z-index: 2;
   top: 5rem;
   left: 1rem;
@@ -26,7 +26,7 @@ const BackArrow = styled.button`
 
 const HeaderGrid = styled(Grid)`
   width: 100%;
-  position: fixed;
+  position: absolute;
   z-index: 1;
   padding: 64px 82px 10px 82px;
   background-color: #a3f4e4;

--- a/src/frontend/components/ProfileTemplate/Header/Header.js
+++ b/src/frontend/components/ProfileTemplate/Header/Header.js
@@ -27,7 +27,6 @@ const BackArrow = styled.button`
 const HeaderGrid = styled(Grid)`
   width: 100%;
   position: relative;
-  margin-bottom: -150px;
   overflow: auto;
   z-index: 1;
   padding: 64px 82px 10px 82px;

--- a/src/frontend/pages/recruitment/ApplicationProfile/ApplicationProfilePage.js
+++ b/src/frontend/pages/recruitment/ApplicationProfile/ApplicationProfilePage.js
@@ -25,7 +25,7 @@ const ContentGrid = styled(Grid)`
   position: relative;
   top: 12rem;
   z-index: 0;
-  padding: 64px 82px 64px 82px;
+  padding: 0px 82px 64px 82px;
 `;
 
 const PostingGrid = styled(Grid)`

--- a/src/frontend/pages/recruitment/InterviewProfile/InterviewProfilePage.js
+++ b/src/frontend/pages/recruitment/InterviewProfile/InterviewProfilePage.js
@@ -22,7 +22,7 @@ const ContentGrid = styled(Grid)`
   position: relative;
   top: 9rem;
   z-index: 0;
-  padding: 64px 82px 64px 82px;
+  padding: 0px 82px 64px 82px;
 `;
 
 const InterviewContainer = styled(Grid)`


### PR DESCRIPTION
### [CLICKUP TICKET LINK](https://app.clickup.com/t/860pnapxx)

## Summary

- **Issue:** An applicant with a longer name (that causes it to be broken up into multiple lines) was causing the header div to cover/hide the rest of the components on `/recruitment/interview/<any_id>` and `/recruitment/applicant/<any_id>`
-  **Change:** Padding and position styles were updated to ensure that the header component does not cover other existing components when the height increases

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing Instructions

To manually test the style changes on the frontend:
- Navigate to `/recruitment/interview/<any_id>` where `<any_id>` can be random characters, or correspond to a test applicant if created
- Add/update the existing `h1` tag by inspecting representing the name of the applicant to a longer name that may take up multiple lines, for example, "ThisIsALongFirstName ThisIsAVeryVeryVeryVeryLongLastName" (can be done using inspect element in your browser)
    -  Ensure that the header div does not cover/hide any of the remaining components on the page (meaning that we are able to view both the Full Name of the applicant, as well as the rest of the components in the main content)

Note:
- These changes also apply to `/recruitment/application/<any_id>`

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation/READ-ME/UMLS (if applicable)
- [x] My changes generate no new warnings
